### PR TITLE
Fix isGamebananaScreenshotData

### DIFF
--- a/src/hooks/gamebananaApi.ts
+++ b/src/hooks/gamebananaApi.ts
@@ -114,14 +114,14 @@ export const useGamebananaApiUrl = <
 
 
 type GamebananaScreenshotData = {
-    _nFilesize: number;
-    _sCaption: string;
+    _nFilesize?: number;
+    _sCaption?: string;
     _sFile: string;
-    _sFile100: string;
+    _sFile100?: string;
     _sFile220?: string;
     _sFile530?: string;
     _sFile800?: string;
-    _sTicketId: string;
+    _sTicketId?: string;
 };
 
 
@@ -134,18 +134,18 @@ const isGamebananaScreenshotData = (
 
 
     if (
-        typeof dataObject._nFilesize === "number" &&
-        typeof dataObject._sCaption === "string" &&
+        (!dataObject._nFilesize || typeof dataObject._nFilesize === "number") &&
+        (!dataObject._sCaption || typeof dataObject._sCaption === "string") &&
         typeof dataObject._sFile === "string" &&
-        typeof dataObject._sFile100 === "string" &&
+        (!dataObject._sFile100 || typeof dataObject._sFile100 === "string") &&
         (!dataObject._sFile220 || typeof dataObject._sFile220 === "string") &&
         (!dataObject._sFile530 || typeof dataObject._sFile530 === "string") &&
         (!dataObject._sFile800 || typeof dataObject._sFile800 === "string") &&
-        typeof dataObject._sTicketId === "string"
-    ) return false;
+        (!dataObject._sTicketId || typeof dataObject._sTicketId === "string")
+    ) return true;
 
 
-    return true;
+    return false;
 };
 
 

--- a/src/hooks/gamebananaApi.ts
+++ b/src/hooks/gamebananaApi.ts
@@ -113,15 +113,9 @@ export const useGamebananaApiUrl = <
 
 
 
+/** Contains other properties, but we don't use them so they aren't specified or checked. */
 type GamebananaScreenshotData = {
-    _nFilesize?: number;
-    _sCaption?: string;
     _sFile: string;
-    _sFile100?: string;
-    _sFile220?: string;
-    _sFile530?: string;
-    _sFile800?: string;
-    _sTicketId?: string;
 };
 
 
@@ -132,18 +126,7 @@ const isGamebananaScreenshotData = (
 
     const dataObject = data as Record<string, unknown>;
 
-
-    if (
-        (!dataObject._nFilesize || typeof dataObject._nFilesize === "number") &&
-        (!dataObject._sCaption || typeof dataObject._sCaption === "string") &&
-        typeof dataObject._sFile === "string" &&
-        (!dataObject._sFile100 || typeof dataObject._sFile100 === "string") &&
-        (!dataObject._sFile220 || typeof dataObject._sFile220 === "string") &&
-        (!dataObject._sFile530 || typeof dataObject._sFile530 === "string") &&
-        (!dataObject._sFile800 || typeof dataObject._sFile800 === "string") &&
-        (!dataObject._sTicketId || typeof dataObject._sTicketId === "string")
-    ) return true;
-
+    if (typeof dataObject._sFile === "string") return true;
 
     return false;
 };


### PR DESCRIPTION
Closes #638.

This is the screenshots data for a random mod:
```
[
  {
     "_sFile":"58c06cce847b5.webp",
     "_sFieldName":"screenshots",
     "_sRelativeImageDir":"img\/ss\/mods",
     "_sFile220":"220-90_58c06cce847b5.webp",
     "_sFile530":"530-90_58c06cce847b5.webp",
     "_sFile100":"100-90_58c06cce847b5.webp"
 }, 
 {
     "_sFile":"58c06cce9ad1f.webp",
     "_sFieldName":"screenshots",
     "_sRelativeImageDir":"img\/ss\/mods",
     "_sFile100":"100-90_58c06cce9ad1f.webp"
 }, 
 {
    "_sFile":"58c06cceb55d0.webp",
    "_sFieldName":"screenshots",
    "_sRelativeImageDir":"img\/ss\/mods",
    "_sFile100":"100-90_58c06cceb55d0.webp"
 }
]
```

This is the screenshots data for [Cat Isle](https://gamebanana.com/mods/332117):
```
[
  {
    "_sCaption": "",
    "_sFile": "617d69d3b32b1.jpg",
    "_nFilesize": 214269,
    "_sFieldName": "screenshots",
    "_sRelativeImageDir": "img/ss/mods",
    "_sFile530": "530-90_617d69d3b32b1.jpg",
    "_sFile100": "100-90_617d69d3b32b1.jpg",
    "_sFile220": "220-90_617d69d3b32b1.jpg",
    "_sFile800": "800-90_617d69d3b32b1.jpg",
    "_hFile220": 123,
    "_wFile220": 220,
    "_hFile530": 298,
    "_wFile530": 530,
    "_hFile100": 56,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sFile": "617d69b7b78a6.jpg",
    "_nFilesize": 173819,
    "_sFieldName": "screenshots",
    "_sRelativeImageDir": "img/ss/mods",
    "_sFile100": "100-90_617d69b7b78a6.jpg",
    "_hFile100": 56,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sFile": "617d69bec4d82.jpg",
    "_nFilesize": 179025,
    "_sFieldName": "screenshots",
    "_sRelativeImageDir": "img/ss/mods",
    "_sFile100": "100-90_617d69bec4d82.jpg",
    "_hFile100": 56,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sFile": "617d69c359a92.jpg",
    "_nFilesize": 146900,
    "_sFieldName": "screenshots",
    "_sRelativeImageDir": "img/ss/mods",
    "_sFile100": "100-90_617d69c359a92.jpg",
    "_hFile100": 56,
    "_wFile100": 100
  }
]
```

This is the screenshots data for [Mount Everest](https://gamebanana.com/mods/150513):
```
[
  {
    "_sCaption": "",
    "_sTicketId": "1c7522a14a5658a6899a8cf32b0f75c2",
    "_sFile": "5ecd0b503862e.jpg",
    "_nFilesize": 750909,
    "_sFile220": "220-90_5ecd0b503862e.jpg",
    "_sFile530": "530-90_5ecd0b503862e.jpg",
    "_sFile100": "100-90_5ecd0b503862e.jpg",
    "_hFile220": 123,
    "_wFile220": 220,
    "_hFile530": 298,
    "_wFile530": 530,
    "_hFile100": 56,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sTicketId": "95df7f7324e075010c85c726760cd68d",
    "_sFile": "5ecd0b5069c05.jpg",
    "_nFilesize": 478929,
    "_sFile100": "100-90_5ecd0b5069c05.jpg",
    "_hFile100": 54,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sTicketId": "23c71863f4ac1c29c96dc535dfeb02de",
    "_sFile": "5ecd0b4c628e1.jpg",
    "_nFilesize": 629109,
    "_sFile100": "100-90_5ecd0b4c628e1.jpg",
    "_hFile100": 55,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sTicketId": "05726ff26ff4e802e061b9d67ec20d1f",
    "_sFile": "5ecd0b4c56014.jpg",
    "_nFilesize": 853791,
    "_sFile100": "100-90_5ecd0b4c56014.jpg",
    "_hFile100": 55,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sTicketId": "1f22c922e39c53de6b4857a3a207c202",
    "_sFile": "5ecd0b4db620a.jpg",
    "_nFilesize": 462052,
    "_sFile100": "100-90_5ecd0b4db620a.jpg",
    "_hFile100": 55,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sTicketId": "662844dd8e3882f4785ecc61de726af2",
    "_sFile": "5ecd0b4cbebb6.jpg",
    "_nFilesize": 671329,
    "_sFile100": "100-90_5ecd0b4cbebb6.jpg",
    "_hFile100": 54,
    "_wFile100": 100
  },
  {
    "_sCaption": "",
    "_sTicketId": "4b61e8c7be391bb1383ef071e2638f29",
    "_sFile": "5ecd0b4d75782.jpg",
    "_nFilesize": 573364,
    "_sFile100": "100-90_5ecd0b4d75782.jpg",
    "_hFile100": 55,
    "_wFile100": 100
  }
]
```

This is the code to check if an object is a screenshot:
https://github.com/celestemods-com/CelesteMods/blob/c247a47937815ef230318ace1287a465ac1fb136/src/hooks/gamebananaApi.ts#L128-L149

I think the `return false;` after the checks and the `return true;` at the end need to be exchanged. Also `_sTicket`, `_nFileSize`, `_sCaption` (and maybe even `_sFile100`) need not be there in the response, so we have to check that. I've made those changes.

Why are we checking for these fields? We only need the `_sFile` field right? Then we could just check for it.