### PR TITLE
Get All Colors From `~/styles` Or Mantine Theme

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -2,27 +2,32 @@ import { Box, Group, Stack, createStyles } from "@mantine/core";
 import Link from "next/link";
 import { cmlDiscordInviteUrl } from "~/consts/cmlDiscordInviteUrl";
 import { COMING_SOON_PATHNAME } from "~/consts/pathnames";
+import { blackBackgroundColor } from "~/styles/layoutColors";
+import { difficultyColors } from "~/styles/mods-colors";
 
 
 
 
-const useStyles = createStyles(() => ({
-    outerFooter: {
-        backgroundColor: "rgba(1.0, 1.0, 1.0, 0.9)",
-        /* top | left and right | bottom */
-        padding: "1px 10px 10px",
-    },
-    footer: {
-        padding: "0 12px",
-    },
-    horizontalRule: {
-        border: "2px solid #5b8bb3",
-    },
-    discordLink: {
-        fontWeight: "bold",
-        textAlign: "center",
-    },
-}));
+const useStyles = createStyles(
+    () => ({
+        outerFooter: {
+            backgroundColor: blackBackgroundColor,
+            /* top | left and right | bottom */
+            padding: "1px 10px 10px",
+        },
+        footer: {
+            padding: "0 12px",
+        },
+        horizontalRule: {
+            border: "2px solid",
+            borderColor: difficultyColors.beginner.primaryHover1,
+        },
+        discordLink: {
+            fontWeight: "bold",
+            textAlign: "center",
+        },
+    })
+);
 
 
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,24 +1,27 @@
 import { Flex, createStyles, Title, Box } from "@mantine/core";
 import Image from "next/image";
 import cmlLogo from "~/../public/images/logo/cml_logo.png";
+import { blackBackgroundColor } from "~/styles/layoutColors";
 
 
 
 
-const useStyles = createStyles(() => ({
-    header: {
-        color: "white",
-        backgroundColor: "rgba(1.0, 1.0, 1.0, 0.9)",
-        padding: "10px 45px",
-        alignItems: "center",
-    },
-    siteTitle: {
-        fontSize: "45px",
-        flexGrow: 1,
-        textAlign: "center",
-        margin: "0",
-    }
-}));
+const useStyles = createStyles(
+    (theme) => ({
+        header: {
+            color: theme.white,
+            backgroundColor: blackBackgroundColor,
+            padding: "10px 45px",
+            alignItems: "center",
+        },
+        siteTitle: {
+            fontSize: "45px",
+            flexGrow: 1,
+            textAlign: "center",
+            margin: "0",
+        }
+    })
+);
 
 
 

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -6,6 +6,7 @@ import { Navbar } from "./navbar/navbar";
 import { Footer } from "./footer";
 import { getNonEmptyArray } from "~/utils/getNonEmptyArray";
 import { MODS_PAGE_PATHNAME } from "~/consts/pathnames";
+import { blackBackgroundColor } from "~/styles/layoutColors";
 
 
 
@@ -18,18 +19,20 @@ const PAGES = getNonEmptyArray([
 
 
 
-const useStyles = createStyles(() => ({
-    backgroundImage: {
-        minWidth: "100vw",
-        minHeight: "100vh",
-        padding: "20px",
-    },
-    children: {
-        backgroundColor: "rgba(1.0, 1.0, 1.0, 0.9)",
-        height: "630px",
-        padding: "5px 45px",
-    },
-}));
+const useStyles = createStyles(
+    () => ({
+        backgroundImage: {
+            minWidth: "100vw",
+            minHeight: "100vh",
+            padding: "20px",
+        },
+        children: {
+            backgroundColor: blackBackgroundColor,
+            height: "630px",
+            padding: "5px 45px",
+        },
+    })
+);
 
 
 

--- a/src/components/layout/navbar/navLink.tsx
+++ b/src/components/layout/navbar/navLink.tsx
@@ -1,30 +1,33 @@
 import { Flex, createStyles } from "@mantine/core";
 import Link from "next/link";
+import { difficultyColors } from "~/styles/mods-colors";
 
 
 
 
-const useStyles = createStyles((theme) => ({
-    navLink: {
-        width: "150px",
-        height: "40px",
-        position: "relative",
-    },
-    navLinkLabel: {
-        backgroundColor: "#263972",
-        color: theme.white,
-        flexGrow: 1,
-        fontSize: '17px',
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        fontWeight: "bold",
-    },
-    activeNavLink: {
-        position: "absolute",
-        right: "-40px",
-    },
-}));
+const useStyles = createStyles(
+    (theme) => ({
+        navLink: {
+            width: "150px",
+            height: "40px",
+            position: "relative",
+        },
+        navLinkLabel: {
+            backgroundColor: difficultyColors.beginner.primary,
+            color: theme.white,
+            flexGrow: 1,
+            fontSize: '17px',
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            fontWeight: "bold",
+        },
+        activeNavLink: {
+            position: "absolute",
+            right: "-40px",
+        },
+    })
+);
 
 
 
@@ -54,7 +57,7 @@ export const NavLink = ({ label, pathname, active }: NavLinkProps) => {
                     xmlns="http://www.w3.org/2000/svg"
                     width="40px"
                     height="40px"
-                    fill="#263972"
+                    fill={difficultyColors.beginner.primary}
                 >
                     <polygon points="0,0 100,0 100,100 0,100 100,50" />
                 </svg>
@@ -67,7 +70,7 @@ export const NavLink = ({ label, pathname, active }: NavLinkProps) => {
                         xmlns="http://www.w3.org/2000/svg"
                         width="40px"
                         height="40px"
-                        fill="#263972"
+                        fill={difficultyColors.beginner.primary}
                         className={classes.activeNavLink}
                     >
                         <polygon points="0,0 100,50 0,100" />

--- a/src/components/mods/modsTable.tsx
+++ b/src/components/mods/modsTable.tsx
@@ -35,7 +35,7 @@ const useStyles = createStyles(
                 justifyContent: "end",
             },
             tab: {
-                color: "white",
+                color: theme.white,
                 padding: "1px 20px",
                 display: "inline-block",
                 borderTopLeftRadius: "5px",
@@ -48,22 +48,22 @@ const useStyles = createStyles(
                 "button": {
                     border: "none",
                 },
-                backgroundColor: colors ? colors.primary : "black",
-                color: "white",
+                backgroundColor: colors ? colors.primary : theme.black,
+                color: theme.white,
                 "&&&& button": {
-                    backgroundColor: colors ? colors.secondary : "black",
+                    backgroundColor: colors ? colors.secondary : theme.black,
                 },
                 "&&&& button:hover": {
-                    backgroundColor: colors ? colors.secondaryHover : "black",
+                    backgroundColor: colors ? colors.secondaryHover : theme.black,
                 },
                 '&&&&& button[data-active]': {
-                    backgroundColor: colors ? colors.primaryHover1 : "black",
+                    backgroundColor: colors ? colors.primaryHover1 : theme.black,
                 },
                 '&&&&& button[data-active]:hover': {
-                    backgroundColor: colors ? colors.primaryHover2 : "black",
+                    backgroundColor: colors ? colors.primaryHover2 : theme.black,
                 },
                 '&&&&&& button[data-disabled]': {
-                    backgroundColor: colors ? colors.secondaryDisabled : "black",
+                    backgroundColor: colors ? colors.secondaryDisabled : theme.black,
                 },
             },
             beginner: {
@@ -103,7 +103,7 @@ const useStyles = createStyles(
                 "&&&&": {
                     /* top | left and right | bottom */
                     padding: `${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.sm}`,
-                    backgroundColor: "#e1e1e2",
+                    backgroundColor: theme.colors.gray[2],
                     color: theme.black,
                     borderWidth: 0,
                     fontWeight: "bold",
@@ -121,34 +121,34 @@ const useStyles = createStyles(
                     padding: "10px",
                     textAlign: "center",
                     border: "none",
-                    backgroundColor: colors ? colors.primary : "black",
+                    backgroundColor: colors ? colors.primary : theme.black,
                     // The down arrow appears blurry due to rotation, so we zoom in to fix that.
                     // https://stackoverflow.com/a/53556981
                     ".mantine-Center-root": {
                         zoom: 1.1,
                     },
                     "svg": {
-                        color: "white",
+                        color: theme.white,
                     }
                 },
                 "&&&& th:hover": {
-                    backgroundColor: colors ? colors.primaryHover1 : "black",
+                    backgroundColor: colors ? colors.primaryHover1 : theme.black,
                 },
             },
             columnTitle: {
                 "&&&& .mantine-UnstyledButton-root": {
                     border: "none",
                     ":hover": {
-                        backgroundColor: colors ? colors.primaryHover2 : "black",
+                        backgroundColor: colors ? colors.primaryHover2 : theme.black,
                     }
                 }
             },
             filteredColumnTitle: {
                 "&&&& .mantine-UnstyledButton-root": {
                     border: "none",
-                    backgroundColor: colors ? colors.primaryHover1 : "black",
+                    backgroundColor: colors ? colors.primaryHover1 : theme.black,
                     ":hover": {
-                        backgroundColor: colors ? colors.primaryHover2 : "black",
+                        backgroundColor: colors ? colors.primaryHover2 : theme.black,
                     }
                 }
             },

--- a/src/styles/layoutColors.ts
+++ b/src/styles/layoutColors.ts
@@ -1,0 +1,1 @@
+export const blackBackgroundColor = "rgba(1.0, 1.0, 1.0, 0.9)";


### PR DESCRIPTION
@ShouvikGhosh2048 When you have a chance, can you please review this PR? It's some refactoring that came out of me working on #713 and #737.

I wanted to remove all color definitions from the various places in our code and import them from the Mantine `theme` or from [~/styles](../tree/main/src/styles). It all seems good to me, but please check that nothing broke and that I didn't miss any color definitions.

For future reference: I used [this page](https://v6.mantine.dev/theming/colors/#default-colors) for picking Mantine colors.