### PR TITLE
Fix tabs extending past table

### DIFF
--- a/src/components/mods/modsTable.tsx
+++ b/src/components/mods/modsTable.tsx
@@ -16,6 +16,7 @@ import { colorsForDifficultyIndex, greatestValidDifficultyIndex } from "~/styles
 import { canonicalDifficultyNames, difficultyColors, type DifficultyColor } from "~/styles/difficultyColors";
 import { expandedModColors } from "~/styles/expandedModColors";
 import { TABLE_HEADER_ARROW_ZOOM } from "~/consts/tableHeaderArrowZoom";
+import { blackBackgroundColor } from "~/styles/layoutColors";
 
 
 
@@ -39,7 +40,7 @@ const useStyles = createStyles(
                 display: "flex",
                 justifyContent: "end",
                 padding: "0 15px",
-                backgroundColor: "theme.black",
+                backgroundColor: blackBackgroundColor,
             },
             tab: {
                 padding: "1px 20px",

--- a/src/components/mods/modsTable.tsx
+++ b/src/components/mods/modsTable.tsx
@@ -33,7 +33,6 @@ const useStyles = createStyles(
     ) => {
         return ({
             tabContainer: {
-                height: "29px",
                 position: "sticky",
                 top: "0",
                 zIndex: 2,

--- a/src/components/mods/modsTable.tsx
+++ b/src/components/mods/modsTable.tsx
@@ -1,5 +1,6 @@
 import { DataTable, DataTableSortStatus } from "mantine-datatable";
 import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import ExpandedMod from "~/components/mods/expandedMod";
 import { createStyles } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
@@ -15,7 +16,6 @@ import { colorsForDifficultyIndex, greatestValidDifficultyIndex } from "~/styles
 import { canonicalDifficultyNames, difficultyColors, type DifficultyColor } from "~/styles/difficultyColors";
 import { expandedModColors } from "~/styles/expandedModColors";
 import { TABLE_HEADER_ARROW_ZOOM } from "~/consts/tableHeaderArrowZoom";
-import { createPortal } from "react-dom";
 
 
 
@@ -39,7 +39,7 @@ const useStyles = createStyles(
                 display: "flex",
                 justifyContent: "end",
                 padding: "0 15px",
-                backgroundColor: "black",
+                backgroundColor: "theme.black",
             },
             tab: {
                 padding: "1px 20px",
@@ -117,7 +117,7 @@ const useStyles = createStyles(
                 "&&&& table": {
                     transform: "translate(0, -21px)",
                     borderSpacing: "0 20px",
-                    padding: "0 15px"
+                    padding: "0 15px",
                 },
                 "&&&& thead": {
                     top: "49px",
@@ -631,26 +631,35 @@ export const ModsTable = ({ qualities, difficulties, modsWithInfo, isLoading }: 
         }
     );
 
-    // We want to render the tab container inside the scroll area of the datatable,
-    // so we use ref and portal.
+
+    // We want to render the tab container inside the scroll area of the datatable, so we use ref and portal.
     const tableBodyRef = useRef<HTMLTableSectionElement>(null);
-    const [tabContainer, setTabContainer] = useState<null | HTMLDivElement>(null);
+    const [tabContainer, setTabContainer] = useState<HTMLDivElement | null>(null);
+
     useEffect(() => {
         const tabsParent = tableBodyRef.current?.parentElement?.parentElement;
+
         if (!tabsParent) {
             throw "Couldn't find tabsParent.";
         }
 
+
         const tabContainer = document.createElement("div");
+
         tabContainer.className = classes.tabContainer;
+
         tabsParent.prepend(tabContainer);
+
         setTabContainer(tabContainer);
+
 
         return () => {
             tabsParent.removeChild(tabContainer);
+            
             setTabContainer(null);
         };
     }, [classes.tabContainer]);
+
 
     return (
         <>

--- a/src/styles/layoutColors.ts
+++ b/src/styles/layoutColors.ts
@@ -1,1 +1,1 @@
-export const blackBackgroundColor = "rgb(25, 25, 25)";    // changed from "rgba(1, 1, 1, 0.9)" because the opacity causes problem when applying this color to the difficulty tab container. this is the same color though.
+export const blackBackgroundColor = "rgb(25, 25, 25)";    // changed from "rgba(1, 1, 1, 0.9)" because the opacity causes problems when applying this color to the difficulty tab container. this is the same color though according to the table at the end of this article https://www.viget.com/articles/equating-color-and-transparency/#table

--- a/src/styles/layoutColors.ts
+++ b/src/styles/layoutColors.ts
@@ -1,1 +1,1 @@
-export const blackBackgroundColor = "rgba(1.0, 1.0, 1.0, 0.9)";
+export const blackBackgroundColor = "rgb(25, 25, 25)";    // changed from "rgba(1, 1, 1, 0.9)" because the opacity causes problem when applying this color to the difficulty tab container. this is the same color though.


### PR DESCRIPTION
Closes #734

Uses [portals](https://react.dev/reference/react-dom/createPortal) to render the tabs container inside the datatable's scroll area.

