### PR TITLE
Implement ISR for `/mods`

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,5 +41,8 @@ const config = {
     locales: ["en"],
     defaultLocale: "en",
   },
+  experimental: {
+    largePageDataBytes: 3 * 1024 * 1024, // 3 MB
+  },
 };
 export default withBundleAnalyzer(config);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "sharp": "^0.33.4",
+        "superjson": "^2.2.1",
         "swagger-ui-react": "^5.17.14",
         "tabler-icons-react": "^1.56.0",
         "trpc-openapi": "^1.2.0",
@@ -3727,6 +3728,20 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.0.0.tgz",
       "integrity": "sha512-mWYvfOLrfEc996hlKcdABeIiPHUPC6DM2QYZdGGOvhOTbA3tjm2eBwqlJpoFdjC89NI4Qt6h0Pu06Mp+1Pj5OQ=="
     },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
@@ -6033,6 +6048,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/isarray": {
@@ -8544,6 +8570,17 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
+    "node_modules/superjson": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
+      "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "sharp": "^0.33.4",
+    "superjson": "^2.2.1",
     "swagger-ui-react": "^5.17.14",
     "tabler-icons-react": "^1.56.0",
     "trpc-openapi": "^1.2.0",

--- a/src/pages/mods/index.tsx
+++ b/src/pages/mods/index.tsx
@@ -269,7 +269,7 @@ const Mods: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
 
     const techQuery = api.tech.getAll.useQuery({}, { queryKey: ["tech.getAll", {}] });
     const techs = techQuery.data ?? [];
-
+    
 
     const modsQuery = api.mod.getAll.useQuery({}, { queryKey: ["mod.getAll", {}] });
 

--- a/src/pages/mods/index.tsx
+++ b/src/pages/mods/index.tsx
@@ -222,71 +222,7 @@ const Mods: NextPage = () => {
 
     const techQuery = api.tech.getAll.useQuery({}, { queryKey: ["tech.getAll", {}] });
     const techs = techQuery.data ?? [];
-
-
-    /*
-        //get all mod ids   //not using pagination because backend pagination is awkward with mantine-datatable     //TODO: implement this
-        const modIdsQuery = api.mod.getIds.useQuery({}, { queryKey: ["mod.getIds", {}] });
-
-        const isLoadingModIds = modIdsQuery.isLoading;
-
-        const modIds = useMemo(() => {
-            if (isLoadingModIds) return [];
-
-
-            const modIds_maybeEmpty: number[] = modIdsQuery.data ?? [];
-
-            if (!modIds_maybeEmpty.length) console.log(`modIds_maybeEmpty is empty. modIds = "${modIds}"`);
-
-
-            return modIds_maybeEmpty;
-        }, [isLoadingModIds, modIdsQuery.data]);
-
-
-        //get mods data
-        const modsQueries = api.useQueries(
-            (useQueriesApi) => modIds.map(
-                (id) => useQueriesApi.mod.getById(
-                    {
-                        id,
-                        tableName: "Mod",
-                    },
-                    {
-                        queryKey: [
-                            "mod.getById",
-                            { id, tableName: "Mod" },
-                        ],
-                    },
-                ),
-            ),
-        );
-
-        const isLoadingMods = isLoadingModIds || modsQueries.some((query) => query.isLoading);
-
-
-        const mods = useMemo(() => {
-            if (isLoadingMods) return [];
-
-
-            const mods_maybeEmpty: Mod[] = [];
-
-            modsQueries.forEach((modQuery) => {
-                if (!modQuery.data) return;
-
-                const mod = {
-                    ...modQuery.data,
-                    isExpanded: false,
-                } as Mod;   //TODO!: prove this cast is safe
-
-                if (mod) mods_maybeEmpty.push(mod);
-            });
-
-            if (!mods_maybeEmpty.length) console.log(`mods_maybeEmpty is empty. modIds = "${modIds}"`);
-
-
-            return mods_maybeEmpty;
-        }, [isLoadingMods, modsQueries]);
-        */
+    
 
     const modsQuery = api.mod.getAll.useQuery({}, { queryKey: ["mod.getAll", {}] });
 

--- a/src/pages/mods/index.tsx
+++ b/src/pages/mods/index.tsx
@@ -1,4 +1,4 @@
-import type { NextPage } from "next";
+import type { InferGetStaticPropsType, NextPage } from "next";
 import { api } from "~/utils/api";
 import { useMemo } from "react";
 import { createStyles, Title } from "@mantine/core";
@@ -9,6 +9,10 @@ import { ModsTable } from "~/components/mods/modsTable";
 import type { ModWithInfo } from "~/components/mods/types";
 import { MODS_PAGE_PATHNAME } from "~/consts/pathnames";
 import { pageTitle } from "~/styles/pageTitle";
+import { createServerSideHelpers } from '@trpc/react-query/server';
+import { appRouter } from "~/server/api/root";
+import { prisma } from "~/server/prisma";
+import superjson from "superjson";
 
 
 
@@ -206,7 +210,50 @@ const getModsWithInfo = (isLoading: boolean, mods: Mod[], ratingsFromModIds: Mod
 
 
 
-const Mods: NextPage = () => {
+export async function getStaticProps() {
+    const helpers = createServerSideHelpers({
+        router: appRouter,
+        ctx: {
+            session: null,
+            prisma: prisma,
+        },
+        transformer: superjson,
+    });
+
+    // prefetch data
+    const promises = [
+        helpers.quality.getAll.prefetch({}),
+    ];
+
+    promises.push(helpers.difficulty.getAll.prefetch({}));
+    promises.push(helpers.publisher.getAll.prefetch({}));
+    promises.push(helpers.tech.getAll.prefetch({}));
+    promises.push(helpers.map.getAll.prefetch({}));
+
+
+    const mods = await helpers.mod.getAll.fetch({});
+
+    mods.forEach((mod) => {
+        promises.push(helpers.rating.getModRatingData.prefetch({ modId: mod.id }));
+    });
+
+
+    await Promise.all(promises);
+
+    return {
+        props: {
+            trpcState: helpers.dehydrate(),
+        },
+        revalidate: 5 * 60, // 5 minutes in seconds
+    };
+};
+
+
+
+
+const Mods: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
+    props,
+) => {
     //get common data
     const qualityQuery = api.quality.getAll.useQuery({}, { queryKey: ["quality.getAll", {}] });
     const qualities = qualityQuery.data ?? [];
@@ -222,7 +269,7 @@ const Mods: NextPage = () => {
 
     const techQuery = api.tech.getAll.useQuery({}, { queryKey: ["tech.getAll", {}] });
     const techs = techQuery.data ?? [];
-    
+
 
     const modsQuery = api.mod.getAll.useQuery({}, { queryKey: ["mod.getAll", {}] });
 


### PR DESCRIPTION
Implements [getStaticProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props) and [Incremental Static Regeneration](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration#using-on-demand-revalidation) for `/mods`.

Follow-up issue required: Reduce `/mods.json` size to <= 168kb (currently 2.07mb) and remove the `largePageDataBytes` from [next.config.mjs](../blob/main/next.config.mjs). This will probably require refactoring the page to use infinite queries for the mods and fetch the maps and ratings on-demand.