### PR TITLE
Move Head element into CustomHead (Fixes #819)

### DIFF
--- a/src/components/layout/customHead.tsx
+++ b/src/components/layout/customHead.tsx
@@ -23,7 +23,6 @@ export function CustomHead({
 
     return (
         <Head>
-            <title>{pageTitle}</title>
             <meta charSet="utf-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
 

--- a/src/components/layout/customHead.tsx
+++ b/src/components/layout/customHead.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import { type LayoutProps } from "./layout";
 
 
@@ -21,7 +22,8 @@ export function CustomHead({
 
 
     return (
-        <>
+        <Head>
+            <title>{pageTitle}</title>
             <meta charSet="utf-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -67,6 +69,6 @@ export function CustomHead({
             <meta name="twitter:description" content={pageDescription} />
             <meta name="twitter:image" content={socialMediaImageUrl} />
             <meta name="twitter:image:alt" content={socialMediaImageAlt} />
-        </>
+        </Head>
     );
 }

--- a/src/components/layout/customHead.tsx
+++ b/src/components/layout/customHead.tsx
@@ -34,11 +34,13 @@ export function CustomHead({
             <link rel="preload" href="/media/renogare/renogare_regular.woff2" as="font" type="font/woff2" crossOrigin />
             */}
 
+
             <title>{pageTitle}</title>
             <meta name="description" content={pageDescription} />
             <meta name="robots" content={robotsText} />
 
             <meta name="application-name" content={siteName} />
+
 
             {/* generated using https://realfavicongenerator.net */}
             {/*favicons*/}
@@ -51,6 +53,7 @@ export function CustomHead({
             <meta name="msapplication-TileColor" content="#2d89ef" />
             <meta name="msapplication-config" content="/images/logo/icon/browserconfig.xml" />
             <meta name="theme-color" content="#2d89ef" />
+
 
             {/*Facebook embed stuff*/}
             <meta property="og:url" content={url} />

--- a/src/components/layout/customHead.tsx
+++ b/src/components/layout/customHead.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { type LayoutProps } from "./layout";
+import type { LayoutProps } from "./layout";
 
 
 

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,5 +1,5 @@
 import { CustomHead } from "./customHead";
-import { BackgroundImage, Grid, Title, createStyles } from "@mantine/core";
+import { BackgroundImage, Grid, createStyles } from "@mantine/core";
 import { Header } from "./header";
 import { Navbar } from "./navbar/navbar";
 import { Footer } from "./footer";

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,6 +1,5 @@
-import Head from "next/head";
 import { CustomHead } from "./customHead";
-import { BackgroundImage, Grid, createStyles } from "@mantine/core";
+import { BackgroundImage, Grid, Title, createStyles } from "@mantine/core";
 import { Header } from "./header";
 import { Navbar } from "./navbar/navbar";
 import { Footer } from "./footer";
@@ -68,17 +67,15 @@ export const Layout = ({
 
     return (
         <>
-            <Head>
-                <CustomHead
-                    pageTitle={pageTitle}
-                    pageDescription={pageDescription}
-                    pathname={pathname}
-                    siteName={siteName}
-                    robotsText={robotsText}
-                    socialMediaImageUrl={socialMediaImageUrl}
-                    socialMediaImageAlt={socialMediaImageAlt}
-                />
-            </Head>
+            <CustomHead
+                pageTitle={pageTitle}
+                pageDescription={pageDescription}
+                pathname={pathname}
+                siteName={siteName}
+                robotsText={robotsText}
+                socialMediaImageUrl={socialMediaImageUrl}
+                socialMediaImageAlt={socialMediaImageAlt}
+            />
             <BackgroundImage
                 src="/images/cml_background1.png"
                 className={classes.backgroundImage}


### PR DESCRIPTION
closes #819

Moving the `<Head>` into `CustomHead` fixes the issue with the title not being recognized.
I'm not entirely sure why this fixes it but apparently nesting elements in `Head` can break things according to the [docs](https://nextjs.org/docs/pages/api-reference/components/head#use-minimal-nesting)

I've tested on latest firefox and chrome on windows 10 and both work fine.
